### PR TITLE
armemu: Fix UXTB16

### DIFF
--- a/src/arm11/armemu.c
+++ b/src/arm11/armemu.c
@@ -6165,12 +6165,12 @@ L_stm_s_takeabort:
 		}
         case 0x6c:
             if ((instr & 0xf03f0) == 0xf0070) { //uxtb16
-                u8 src1 = BITS(0, 3);
-                u8 tar = BITS(12, 15);
-                u32 base = state->Reg[src1];
-                u32 shamt = BITS(9,10)* 8;
-                u32 in = ((base << (32 - shamt)) | (base >> shamt));
-                state->Reg[tar] = in & 0x00FF00FF;
+                u8 rm_idx = BITS(0, 3);
+                u8 rd_idx = BITS(12, 15);
+                u32 rm_val = state->Reg[rm_idx];
+                u32 rotation = BITS(10, 11) * 8;
+                u32 in = ((rm_val << (32 - rotation)) | (rm_val >> rotation));
+                state->Reg[rd_idx] = in & 0x00FF00FF;
                 return 1;
             } else
                 printf ("Unhandled v6 insn: uxtab16\n");


### PR DESCRIPTION
Rotation bits are 10 and 11, not 9 and 10.

See [here](https://github.com/citra-emu/citra/pull/281) for test results regarding this small error.
