### PR TITLE
armemu: Merge QADD16/QSUB16 and fix signed saturation clamping.

### DIFF
--- a/src/arm11/armemu.c
+++ b/src/arm11/armemu.c
@@ -5929,12 +5929,12 @@ L_stm_s_takeabort:
 
                 if (lo_result > 0x7FFF)
                     lo_result = 0x7FFF;
-                else if (lo_result < 0x7FFF)
+                else if (lo_result < -0x8000)
                     lo_result = -0x8000;
 
                 if (hi_result > 0x7FFF)
                     hi_result = 0x7FFF;
-                else if (hi_result < 0x7FFF)
+                else if (hi_result < -0x8000)
                     hi_result = -0x8000;
 
                 state->Reg[rd_idx] = (lo_result & 0xFFFF) | ((hi_result & 0xFFFF) << 16);


### PR DESCRIPTION
See [here](https://github.com/citra-emu/citra/pull/287) for hardware/emu comparisons.
