### PR TITLE
armemu: Fix SSUB16

### DIFF
--- a/src/arm11/armemu.c
+++ b/src/arm11/armemu.c
@@ -5890,14 +5890,14 @@ L_stm_s_takeabort:
             break;
         case 0x61:
             if ((instr & 0xFF0) == 0xf70) { //ssub16
-                u8 tar = BITS(12, 15);
-                u8 src1 = BITS(16, 19);
-                u8 src2 = BITS(0, 3);
-                s16 a1 = (state->Reg[src1] & 0xFFFF);
-                s16 a2 = ((state->Reg[src1] >> 0x10) & 0xFFFF);
-                s16 b1 = (state->Reg[src2] & 0xFFFF);
-                s16 b2 = ((state->Reg[src2] >> 0x10) & 0xFFFF);
-				state->Reg[tar] = ((a1 - a2) & 0xFFFF) | (((b1 - b2) & 0xFFFF) << 0x10);
+                const u8 rd_idx = BITS(12, 15);
+                const u8 rm_idx = BITS(0, 3);
+                const u8 rn_idx = BITS(16, 19);
+                const s16 rn_lo = (state->Reg[rn_idx] & 0xFFFF);
+                const s16 rn_hi = ((state->Reg[rn_idx] >> 16) & 0xFFFF);
+                const s16 rm_lo = (state->Reg[rm_idx] & 0xFFFF);
+                const s16 rm_hi = ((state->Reg[rm_idx] >> 16) & 0xFFFF);
+                state->Reg[rd_idx] = ((rn_lo - rm_lo) & 0xFFFF) | (((rn_hi - rm_hi) & 0xFFFF) << 16);
                 return 1;
             } else if ((instr & 0xFF0) == 0xf10) { //sadd16
                 const u8 rd_idx = BITS(12, 15);


### PR DESCRIPTION
Broken from the same reason SADD16 was.

The lo part of the result should only be constructed from the lo halfwords of rm and rn.
The hi part of the result should only be constructed from the hi halfwords of rm and rn.
