### PR TITLE
armemu: Fix retrieval of the CPSR for MRS instructions.

### DIFF
--- a/src/arm11/armemu.c
+++ b/src/arm11/armemu.c
@@ -1787,7 +1787,7 @@ mainswitch:
                             TAKEABORT;
                     } else if ((BITS (0, 11) == 0) && (LHSReg == 15)) {	/* MRS CPSR */
                         UNDEF_MRSPC;
-                        DEST = ECC | EINT | EMODE;
+                        DEST = ARMul_GetCPSR(state);
                     } else {
                         UNDEF_Test;
                     }


### PR DESCRIPTION
Prior to this it would only retrieve some of the flags. Whenever GE/Q flag support is added, they will now correctly show up in MRS calls.
