### PR TITLE
armemu: Fix error in Q/GE flag setting

### DIFF
--- a/src/arm11/armemu.c
+++ b/src/arm11/armemu.c
@@ -5926,22 +5926,21 @@ L_stm_s_takeabort:
                 state->Reg[rd_idx] = (lo_result & 0xFFFF) | ((hi_result & 0xFFFF) << 16);
 
                 if (lo_result >= 0) {
-                    state->Cpsr |= (1 << 16);
-                    state->Cpsr |= (1 << 17);
+                    state->GEFlag |= (1 << 16);
+                    state->GEFlag |= (1 << 17);
                 } else {
-                    state->Cpsr &= ~(1 << 16);
-                    state->Cpsr &= ~(1 << 17);
+                    state->GEFlag &= ~(1 << 16);
+                    state->GEFlag &= ~(1 << 17);
                 }
 
                 if (hi_result >= 0) {
-                    state->Cpsr |= (1 << 18);
-                    state->Cpsr |= (1 << 19);
+                    state->GEFlag |= (1 << 18);
+                    state->GEFlag |= (1 << 19);
                 } else {
-                    state->Cpsr &= ~(1 << 18);
-                    state->Cpsr &= ~(1 << 19);
+                    state->GEFlag &= ~(1 << 18);
+                    state->GEFlag &= ~(1 << 19);
                 }
 
-                ARMul_CPSRAltered(state);
                 return 1;
             }
             else if ((instr & 0xFF0) == 0xf90 || (instr & 0xFF0) == 0xff0)
@@ -5965,24 +5964,24 @@ L_stm_s_takeabort:
                     hi_val2 = (u8)(((rn_val >> 24) & 0xFF) + ((rm_val >> 24) & 0xFF));
 
                     if (lo_val1 & 0x80)
-                        state->Cpsr |= (1 << 16);
+                        state->GEFlag |= (1 << 16);
                     else
-                        state->Cpsr &= ~(1 << 16);
+                        state->GEFlag &= ~(1 << 16);
 
                     if (lo_val2 & 0x80)
-                        state->Cpsr |= (1 << 17);
+                        state->GEFlag |= (1 << 17);
                     else
-                        state->Cpsr &= ~(1 << 17);
+                        state->GEFlag &= ~(1 << 17);
 
                     if (hi_val1 & 0x80)
-                        state->Cpsr |= (1 << 18);
+                        state->GEFlag |= (1 << 18);
                     else
-                        state->Cpsr &= ~(1 << 18);
+                        state->GEFlag &= ~(1 << 18);
 
                     if (hi_val2 & 0x80)
-                        state->Cpsr |= (1 << 19);
+                        state->GEFlag |= (1 << 19);
                     else
-                        state->Cpsr &= ~(1 << 19);
+                        state->GEFlag &= ~(1 << 19);
                 }
                 // SSUB8
                 else {
@@ -5992,27 +5991,26 @@ L_stm_s_takeabort:
                     hi_val2 = (u8)(((rn_val >> 24) & 0xFF) - ((rm_val >> 24) & 0xFF));
 
                     if (!(lo_val1 & 0x80))
-                        state->Cpsr |= (1 << 16);
+                        state->GEFlag |= (1 << 16);
                     else
-                        state->Cpsr &= ~(1 << 16);
+                        state->GEFlag &= ~(1 << 16);
 
                     if (!(lo_val2 & 0x80))
-                        state->Cpsr |= (1 << 17);
+                        state->GEFlag |= (1 << 17);
                     else
-                        state->Cpsr &= ~(1 << 17);
+                        state->GEFlag &= ~(1 << 17);
 
                     if (!(hi_val1 & 0x80))
-                        state->Cpsr |= (1 << 18);
+                        state->GEFlag |= (1 << 18);
                     else
-                        state->Cpsr &= ~(1 << 18);
+                        state->GEFlag &= ~(1 << 18);
 
                     if (!(hi_val2 & 0x80))
-                        state->Cpsr |= (1 << 19);
+                        state->GEFlag |= (1 << 19);
                     else
-                        state->Cpsr &= ~(1 << 19);
+                        state->GEFlag &= ~(1 << 19);
                 }
 
-                ARMul_CPSRAltered(state);
                 state->Reg[rd_idx] = (lo_val1 | lo_val2 << 8 | hi_val1 << 16 | hi_val2 << 24);
                 return 1;
             }
@@ -6091,31 +6089,30 @@ L_stm_s_takeabort:
                     h2 = ((u16)(from >> 16) - (u16)(to >> 16));
 
                     if (!(h1 & 0xffff0000))
-                        state->Cpsr |= (3 << 16);
+                        state->GEFlag |= (3 << 16);
                     else
-                        state->Cpsr &= ~(3 << 16);
+                        state->GEFlag &= ~(3 << 16);
 
                     if (!(h2 & 0xffff0000))
-                        state->Cpsr |= (3 << 18);
+                        state->GEFlag |= (3 << 18);
                     else
-                        state->Cpsr &= ~(3 << 18);
+                        state->GEFlag &= ~(3 << 18);
                 }
                 else { // UADD16
                     h1 = ((u16)from + (u16)to);
                     h2 = ((u16)(from >> 16) + (u16)(to >> 16));
 
                     if (h1 & 0xffff0000)
-                        state->Cpsr |= (3 << 16);
+                        state->GEFlag |= (3 << 16);
                     else
-                        state->Cpsr &= ~(3 << 16);
+                        state->GEFlag &= ~(3 << 16);
 
                     if (h2 & 0xffff0000)
-                        state->Cpsr |= (3 << 18);
+                        state->GEFlag |= (3 << 18);
                     else
-                        state->Cpsr &= ~(3 << 18);
+                        state->GEFlag &= ~(3 << 18);
                 }
 
-                ARMul_CPSRAltered(state);
                 state->Reg[rd] = (u32)((h1 & 0xffff) | ((h2 & 0xffff) << 16));
                 return 1;
             }
@@ -6130,24 +6127,24 @@ L_stm_s_takeabort:
                         b4 = ((u8)(from >> 24) - (u8)(to >> 24));
 
                         if (!(b1 & 0xffffff00))
-                            state->Cpsr |= (1 << 16);
+                            state->GEFlag |= (1 << 16);
                         else
-                            state->Cpsr &= ~(1 << 16);
+                            state->GEFlag &= ~(1 << 16);
 
                         if (!(b2 & 0xffffff00))
-                            state->Cpsr |= (1 << 17);
+                            state->GEFlag |= (1 << 17);
                         else
-                            state->Cpsr &= ~(1 << 17);
+                            state->GEFlag &= ~(1 << 17);
 
                         if (!(b3 & 0xffffff00))
-                            state->Cpsr |= (1 << 18);
+                            state->GEFlag |= (1 << 18);
                         else
-                            state->Cpsr &= ~(1 << 18);
+                            state->GEFlag &= ~(1 << 18);
 
                         if (!(b4 & 0xffffff00))
-                            state->Cpsr |= (1 << 19);
+                            state->GEFlag |= (1 << 19);
                         else
-                            state->Cpsr &= ~(1 << 19);
+                            state->GEFlag &= ~(1 << 19);
                     }
                     else { // UADD8
                         b1 = ((u8)from + (u8)to);
@@ -6156,28 +6153,27 @@ L_stm_s_takeabort:
                         b4 = ((u8)(from >> 24) + (u8)(to >> 24));
 
                         if (b1 & 0xffffff00)
-                            state->Cpsr |= (1 << 16);
+                            state->GEFlag |= (1 << 16);
                         else
-                            state->Cpsr &= ~(1 << 16);
+                            state->GEFlag &= ~(1 << 16);
 
                         if (b2 & 0xffffff00)
-                            state->Cpsr |= (1 << 17);
+                            state->GEFlag |= (1 << 17);
                         else
-                            state->Cpsr &= ~(1 << 17);
+                            state->GEFlag &= ~(1 << 17);
 
                         if (b3 & 0xffffff00)
-                            state->Cpsr |= (1 << 18);
+                            state->GEFlag |= (1 << 18);
                         else
-                            state->Cpsr &= ~(1 << 18);
+                            state->GEFlag &= ~(1 << 18);
 
 
                         if (b4 & 0xffffff00)
-                            state->Cpsr |= (1 << 19);
+                            state->GEFlag |= (1 << 19);
                         else
-                            state->Cpsr &= ~(1 << 19);
+                            state->GEFlag &= ~(1 << 19);
                     }
 
-                    ARMul_CPSRAltered(state);
                     state->Reg[rd] = (u32)(b1 | (b2 & 0xff) << 8 | (b3 & 0xff) << 16 | (b4 & 0xff) << 24);
                     return 1;
                 }
@@ -6274,21 +6270,20 @@ L_stm_s_takeabort:
 
 					if (rn_lo > max) {
 						rn_lo = max;
-						state->Cpsr |= (1 << 27);
+						SETQ;
 					} else if (rn_lo < min) {
 						rn_lo = min;
-						state->Cpsr |= (1 << 27);
+						SETQ;
 					}
 
 					if (rn_hi > max) {
 						rn_hi = max;
-						state->Cpsr |= (1 << 27);
+						SETQ;
 					} else if (rn_hi < min) {
 						rn_hi = min;
-						state->Cpsr |= (1 << 27);
+						SETQ;
 					}
 
-					ARMul_CPSRAltered(state);
 					state->Reg[rd_idx] = (rn_lo & 0xFFFF) | ((rn_hi & 0xFFFF) << 16);
 					return 1;
 				}
@@ -6424,21 +6419,20 @@ L_stm_s_takeabort:
 
 					if (rn_lo > max) {
 						rn_lo = max;
-						state->Cpsr |= (1 << 27);
+						SETQ;
 					} else if (rn_lo < 0) {
 						rn_lo = 0;
-						state->Cpsr |= (1 << 27);
+						SETQ;
 					}
 
 					if (rn_hi > max) {
 						rn_hi = max;
-						state->Cpsr |= (1 << 27);
+						SETQ;
 					} else if (rn_hi < 0) {
 						rn_hi = 0;
-						state->Cpsr |= (1 << 27);
+						SETQ;
 					}
 
-					ARMul_CPSRAltered(state);
 					state->Reg[rd_idx] = (rn_lo & 0xFFFF) | ((rn_hi << 16) & 0xFFFF);
 					return 1;
 				}


### PR DESCRIPTION
Should be set directly because I overlooked the fact CPSRAltered flushes current state.
